### PR TITLE
Add timeout tests for solvers

### DIFF
--- a/gips.ilp.timeout.timeoutmodel/.classpath
+++ b/gips.ilp.timeout.timeoutmodel/.classpath
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="gen"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/gips.ilp.timeout.timeoutmodel/.gitignore
+++ b/gips.ilp.timeout.timeoutmodel/.gitignore
@@ -1,0 +1,3 @@
+/bin
+/gen
+/model/*.genmodel

--- a/gips.ilp.timeout.timeoutmodel/.project
+++ b/gips.ilp.timeout.timeoutmodel/.project
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>gips.ilp.timeout.timeoutmodel</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.moflon.emf.build.MoflonEmfBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.moflon.emf.build.MoflonEmfNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+	</natures>
+</projectDescription>

--- a/gips.ilp.timeout.timeoutmodel/.settings/org.eclipse.core.resources.prefs
+++ b/gips.ilp.timeout.timeoutmodel/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/gips.ilp.timeout.timeoutmodel/META-INF/MANIFEST.MF
+++ b/gips.ilp.timeout.timeoutmodel/META-INF/MANIFEST.MF
@@ -1,0 +1,14 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: gips.ilp.timeout.timeoutmodel
+Bundle-SymbolicName: gips.ilp.timeout.timeoutmodel;singleton:=true
+Bundle-Version: 0.0.1.qualifier
+Bundle-Vendor: 
+Bundle-ActivationPolicy: lazy
+Bundle-RequiredExecutionEnvironment: JavaSE-16
+Automatic-Module-Name: gips.ilp.timeout.timeoutmodel
+Require-Bundle: org.eclipse.emf.ecore,
+ org.eclipse.emf.ecore.xmi,
+ org.emoflon.smartemf
+Export-Package: timeoutmodel,
+ timeoutmodel.impl

--- a/gips.ilp.timeout.timeoutmodel/build.properties
+++ b/gips.ilp.timeout.timeoutmodel/build.properties
@@ -1,0 +1,6 @@
+#
+#Thu Sep 08 16:58:11 CEST 2022
+src.excludes=injection/
+bin.includes=META-INF/, bin/, model/, plugin.xml, moflon.properties.xmi
+source..=src/,gen/
+output..=bin/

--- a/gips.ilp.timeout.timeoutmodel/model/Timeoutmodel.ecore
+++ b/gips.ilp.timeout.timeoutmodel/model/Timeoutmodel.ecore
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="ASCII"?>
+<ecore:EPackage xmi:version="2.0"
+  xmlns:xmi="http://www.omg.org/XMI"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore"
+  name="timeoutmodel"
+  nsURI="platform:/resource/gips.ilp.timeout.timeoutmodel/model/Timeoutmodel.ecore"
+  nsPrefix="gips.ilp.timeout.timeoutmodel">
+  <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+    <details key="documentation" value="TODO: Add documentation for timeoutmodel. Hint: You may copy this element in the Ecore editor to add documentation to EClasses, EOperations, ..."/>
+  </eAnnotations>
+</ecore:EPackage>

--- a/gips.ilp.timeout.timeoutmodel/model/Timeoutmodel.ecore
+++ b/gips.ilp.timeout.timeoutmodel/model/Timeoutmodel.ecore
@@ -1,12 +1,23 @@
 <?xml version="1.0" encoding="ASCII"?>
-<ecore:EPackage xmi:version="2.0"
-  xmlns:xmi="http://www.omg.org/XMI"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore"
-  name="timeoutmodel"
-  nsURI="platform:/resource/gips.ilp.timeout.timeoutmodel/model/Timeoutmodel.ecore"
-  nsPrefix="gips.ilp.timeout.timeoutmodel">
+<ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="timeoutmodel" nsURI="platform:/resource/gips.ilp.timeout.timeoutmodel/model/Timeoutmodel.ecore"
+    nsPrefix="gips.ilp.timeout.timeoutmodel">
   <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
     <details key="documentation" value="TODO: Add documentation for timeoutmodel. Hint: You may copy this element in the Ecore editor to add documentation to EClasses, EOperations, ..."/>
   </eAnnotations>
+  <eClassifiers xsi:type="ecore:EClass" name="Root">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="elements" upperBound="-1"
+        eType="#//Element" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Element" abstract="true">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="id" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="val" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Source" eSuperTypes="#//Element">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="host" eType="#//Target"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Target" eSuperTypes="#//Element">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="free" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="srcs" upperBound="-1" eType="#//Source"/>
+  </eClassifiers>
 </ecore:EPackage>

--- a/gips.ilp.timeout.timeoutmodel/moflon.properties.xmi
+++ b/gips.ilp.timeout.timeoutmodel/moflon.properties.xmi
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="ASCII"?>
+<org.moflon.core.propertycontainer:MoflonPropertiesContainer xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:org.moflon.core.propertycontainer="platform:/plugin/org.moflon.core.propertycontainer/model/Propertycontainer.ecore" projectName="gips.ilp.timeout.timeoutmodel">
+  <genModelProps/>
+  <codeGenerator generator="SMART_EMF"/>
+</org.moflon.core.propertycontainer:MoflonPropertiesContainer>

--- a/gips.ilp.timeout.timeoutmodel/plugin.xml
+++ b/gips.ilp.timeout.timeoutmodel/plugin.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?eclipse version="3.0"?><plugin/>

--- a/gips.ilp.timeout.timeoutmodel/plugin.xml
+++ b/gips.ilp.timeout.timeoutmodel/plugin.xml
@@ -1,2 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?eclipse version="3.0"?><plugin/>
+<?eclipse version="3.0"?><plugin>
+  <extension point="org.eclipse.emf.ecore.generated_package">
+    <package class="timeoutmodel.TimeoutmodelPackage" genModel="model/Timeoutmodel.genmodel" uri="platform:/resource/gips.ilp.timeout.timeoutmodel/model/Timeoutmodel.ecore"/>
+  </extension>
+</plugin>

--- a/gips.ilp.timeout/.classpath
+++ b/gips.ilp.timeout/.classpath
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src-gen"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/gips.ilp.timeout/.project
+++ b/gips.ilp.timeout/.project
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>gips.ilp.timeout</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.emoflon.gips.gipsl.ui.gipsNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/gips.ilp.timeout/.settings/org.eclipse.jdt.core.prefs
+++ b/gips.ilp.timeout/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,10 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=17

--- a/gips.ilp.timeout/META-INF/MANIFEST.MF
+++ b/gips.ilp.timeout/META-INF/MANIFEST.MF
@@ -11,4 +11,7 @@ Require-Bundle: org.emoflon.ibex.common,
  org.emoflon.ibex.gt,
  org.emoflon.gips.core,
  org.emoflon.ibex.gt.democles,
- org.emoflon.ibex.gt.hipe
+ org.emoflon.ibex.gt.hipe,
+ gips.ilp.timeout.timeoutmodel;bundle-version="0.0.1",
+ test.suite.utils;bundle-version="1.0.0"
+Export-Package: gips.ilp.timeout.connector

--- a/gips.ilp.timeout/META-INF/MANIFEST.MF
+++ b/gips.ilp.timeout/META-INF/MANIFEST.MF
@@ -1,0 +1,14 @@
+Manifest-Version: 1.0
+Automatic-Module-Name: gips.ilp.timeout
+Bundle-ManifestVersion: 2
+Bundle-Name: gips.ilp.timeout
+Bundle-Vendor: My Company
+Bundle-Version: 1.0.0.qualifier
+Bundle-SymbolicName: gips.ilp.timeout; singleton:=true
+Bundle-ActivationPolicy: lazy
+Bundle-RequiredExecutionEnvironment: JavaSE-16
+Require-Bundle: org.emoflon.ibex.common,
+ org.emoflon.ibex.gt,
+ org.emoflon.gips.core,
+ org.emoflon.ibex.gt.democles,
+ org.emoflon.ibex.gt.hipe

--- a/gips.ilp.timeout/build.properties
+++ b/gips.ilp.timeout/build.properties
@@ -1,0 +1,5 @@
+source.. = src/,\
+		src-gen/
+bin.includes = META-INF/,\
+		.,\
+		plugin.xml

--- a/gips.ilp.timeout/src/gips/ilp/timeout/Model.gipsl
+++ b/gips.ilp.timeout/src/gips/ilp/timeout/Model.gipsl
@@ -1,39 +1,62 @@
 package "gips.ilp.timeout"
-import "http://www.eclipse.org/emf/2002/Ecore"
-// import a metamodel here
+import "platform:/resource/gips.ilp.timeout.timeoutmodel/model/Timeoutmodel.ecore"
 
 config {  
 	solver := GUROBI [home:="fu", license:="bar"];
-	launchConfig := true [main := "TODO"];
-	timeLimit := true [value := 42.0];
-	randomSeed := true [value := 73];
-	presolve := true;
+	timeLimit := true [value := 0.0];
+	randomSeed := true [value := 0];
+	presolve := false;
 	debugOutput := true;
 }
 
-// specify an example rule
-rule exampleRule {
-	clazz : EClass {
-		++ -eAllOperations -> op
+condition srcNotMapped = forbid srcIsMapped
+pattern srcIsMapped {
+	trg: Target
+	
+	src: Source {
+		-host -> trg
+	}
+}
+
+rule mapSrc {
+	root: Root {
+		-elements -> src
+		-elements -> trg
 	}
 	
-	op : EOperation
+	src: Source {
+		++ -host -> trg
+	}
+	
+	trg: Target {
+		++ -srcs -> src
+		.free := trg.free - src.val
+	}
+	
+	# src.val <= trg.free
+	# trg.free > 0
+	# trg.val > 0
+}
+when srcNotMapped
+
+//
+// GIPSL starts here!
+//
+
+mapping s2t with mapSrc;
+
+constraint -> pattern::mapSrc {
+	mappings.s2t->filter(m | m.nodes().src == self.nodes().src)->count() == 1
 }
 
-// create a mapping on the rule
-mapping mapNode with exampleRule;
-
-// create a constraint on one class
-constraint -> class::EOperation {
-	mappings.mapNode->filter(m | m.nodes().clazz.^abstract)->count() > self.lowerBound
+constraint -> class::Target {
+	mappings.s2t->filter(m | m.nodes().trg == self)->sum(m | m.nodes().src.val) <= self.free
 }
 
-// create an objective for the mapping
-objective nodeObj -> mapping::mapNode {
-	self.nodes().op.upperBound * sin(73)
+objective o -> mapping::s2t {
+	1
 }
 
-// create an overall objective
 global objective : min {
-	2 * nodeObj
+	o
 }

--- a/gips.ilp.timeout/src/gips/ilp/timeout/Model.gipsl
+++ b/gips.ilp.timeout/src/gips/ilp/timeout/Model.gipsl
@@ -1,0 +1,39 @@
+package "gips.ilp.timeout"
+import "http://www.eclipse.org/emf/2002/Ecore"
+// import a metamodel here
+
+config {  
+	solver := GUROBI [home:="fu", license:="bar"];
+	launchConfig := true [main := "TODO"];
+	timeLimit := true [value := 42.0];
+	randomSeed := true [value := 73];
+	presolve := true;
+	debugOutput := true;
+}
+
+// specify an example rule
+rule exampleRule {
+	clazz : EClass {
+		++ -eAllOperations -> op
+	}
+	
+	op : EOperation
+}
+
+// create a mapping on the rule
+mapping mapNode with exampleRule;
+
+// create a constraint on one class
+constraint -> class::EOperation {
+	mappings.mapNode->filter(m | m.nodes().clazz.^abstract)->count() > self.lowerBound
+}
+
+// create an objective for the mapping
+objective nodeObj -> mapping::mapNode {
+	self.nodes().op.upperBound * sin(73)
+}
+
+// create an overall objective
+global objective : min {
+	2 * nodeObj
+}

--- a/gips.ilp.timeout/src/gips/ilp/timeout/connector/TimeOutConnector.java
+++ b/gips.ilp.timeout/src/gips/ilp/timeout/connector/TimeOutConnector.java
@@ -1,0 +1,24 @@
+package gips.ilp.timeout.connector;
+
+import org.emoflon.gips.core.ilp.ILPSolverOutput;
+
+import gips.ilp.timeout.api.gips.TimeoutGipsAPI;
+import test.suite.gips.utils.AConnector;
+import test.suite.gips.utils.GipsTestUtils;
+
+public class TimeOutConnector extends AConnector {
+
+	public TimeOutConnector(final String modelPath) {
+		api = new TimeoutGipsAPI();
+		api.init(GipsTestUtils.pathToAbsUri(modelPath));
+	}
+
+	@Override
+	public ILPSolverOutput run(final String outputPath) {
+		final ILPSolverOutput output = solve();
+		((TimeoutGipsAPI) api).getS2t().applyNonZeroMappings();
+		save(outputPath);
+		return output;
+	}
+
+}

--- a/test.suite.gips/META-INF/MANIFEST.MF
+++ b/test.suite.gips/META-INF/MANIFEST.MF
@@ -14,8 +14,10 @@ Require-Bundle: org.junit.jupiter.api;bundle-version="5.8.1",
  gipsl.all.build.objective.min,
  gips.sort;bundle-version="1.0.0",
  gips.sort.listmodel;bundle-version="0.0.1",
- gipsl.imports.importmodel;bundle-version="0.0.1"
-Import-Package: gips.sort.patternreg.connector,
+ gipsl.imports.importmodel;bundle-version="0.0.1",
+ gips.ilp.timeout.timeoutmodel;bundle-version="0.0.1"
+Import-Package: gips.ilp.timeout.connector,
+ gips.sort.patternreg.connector,
  gipsl.all.build.and.connector,
  gipsl.all.build.count.connector,
  gipsl.all.build.filter.connector,

--- a/test.suite.gips/src/test/suite/gips/ilp/timeout/AGipsIlpTimeOutTest.java
+++ b/test.suite.gips/src/test/suite/gips/ilp/timeout/AGipsIlpTimeOutTest.java
@@ -1,0 +1,14 @@
+package test.suite.gips.ilp.timeout;
+
+import test.suite.gips.utils.AConnector;
+
+public abstract class AGipsIlpTimeOutTest {
+
+	protected final static String MODEL_PATH = "model.xmi";
+	protected final static String OUTPUT_PATH = "output.xmi";
+
+	protected AConnector con;
+
+	protected abstract void callableSetUp();
+
+}

--- a/test.suite.gips/src/test/suite/gips/ilp/timeout/GipsIlpTimeOutTest.java
+++ b/test.suite.gips/src/test/suite/gips/ilp/timeout/GipsIlpTimeOutTest.java
@@ -2,12 +2,13 @@ package test.suite.gips.ilp.timeout;
 
 import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.emoflon.gips.core.ilp.ILPSolverOutput;
 import org.emoflon.gips.core.ilp.ILPSolverStatus;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import gips.ilp.timeout.connector.TimeOutConnector;
@@ -20,6 +21,8 @@ import timeoutmodel.Target;
  */
 public class GipsIlpTimeOutTest extends AGipsIlpTimeOutTest {
 
+	static int missedTimeOutSolutionCntr = 0;
+
 	@BeforeEach
 	public void resetModel() {
 		IlpTimeOutModelGenerator.reset();
@@ -29,6 +32,12 @@ public class GipsIlpTimeOutTest extends AGipsIlpTimeOutTest {
 	public void callableSetUp() {
 		IlpTimeOutModelGenerator.persistModel(MODEL_PATH);
 		con = new TimeOutConnector(MODEL_PATH);
+	}
+
+	@AfterAll
+	public static void verifyAtLeastOneTestWithoutSolution() {
+		assertNotEquals(missedTimeOutSolutionCntr, 3,
+				"The ILP solver did find at least one solution for all three tests.");
 	}
 
 	@Test
@@ -45,9 +54,13 @@ public class GipsIlpTimeOutTest extends AGipsIlpTimeOutTest {
 		IlpTimeOutModelGenerator.loadModel(OUTPUT_PATH);
 		assertEquals(ILPSolverStatus.TIME_OUT, ret.status());
 
-		// TODO: Check if solution was found
-		// There must be no embedding at all -> no solution found -> no solution applied
-		checkNoMapping();
+		if (ret.solutionCount() == 0) {
+			// There must be no embedding at all -> no solution found -> no solution applied
+			checkNoMapping();
+		} else {
+			System.err.println("=> Warning: ILP solver did find a solution.");
+			missedTimeOutSolutionCntr++;
+		}
 	}
 
 	@Test
@@ -64,12 +77,15 @@ public class GipsIlpTimeOutTest extends AGipsIlpTimeOutTest {
 		IlpTimeOutModelGenerator.loadModel(OUTPUT_PATH);
 		assertEquals(ILPSolverStatus.TIME_OUT, ret.status());
 
-		// TODO: Check if solution was found
-		// There must be no embedding at all -> no solution found -> no solution applied
-		checkNoMapping();
+		if (ret.solutionCount() == 0) {
+			// There must be no embedding at all -> no solution found -> no solution applied
+			checkNoMapping();
+		} else {
+			System.err.println("=> Warning: ILP solver did find a solution.");
+			missedTimeOutSolutionCntr++;
+		}
 	}
 
-	@Disabled
 	@Test
 	public void test200to200() {
 		for (int i = 1; i <= 200; i++) {
@@ -84,9 +100,13 @@ public class GipsIlpTimeOutTest extends AGipsIlpTimeOutTest {
 		IlpTimeOutModelGenerator.loadModel(OUTPUT_PATH);
 		assertEquals(ILPSolverStatus.TIME_OUT, ret.status());
 
-		// TODO: Check if solution was found
-		// There must be no embedding at all -> no solution found -> no solution applied
-		checkNoMapping();
+		if (ret.solutionCount() == 0) {
+			// There must be no embedding at all -> no solution found -> no solution applied
+			checkNoMapping();
+		} else {
+			System.err.println("=> Warning: ILP solver did find a solution.");
+			missedTimeOutSolutionCntr++;
+		}
 	}
 
 	private void checkNoMapping() {

--- a/test.suite.gips/src/test/suite/gips/ilp/timeout/GipsIlpTimeOutTest.java
+++ b/test.suite.gips/src/test/suite/gips/ilp/timeout/GipsIlpTimeOutTest.java
@@ -1,0 +1,103 @@
+package test.suite.gips.ilp.timeout;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.emoflon.gips.core.ilp.ILPSolverOutput;
+import org.emoflon.gips.core.ilp.ILPSolverStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import gips.ilp.timeout.connector.TimeOutConnector;
+import timeoutmodel.Source;
+import timeoutmodel.Target;
+
+/**
+ * This test should trigger at least one time out with no solution found. In
+ * this case, the solver's implementation must not throw an exception.
+ */
+public class GipsIlpTimeOutTest extends AGipsIlpTimeOutTest {
+
+	@BeforeEach
+	public void resetModel() {
+		IlpTimeOutModelGenerator.reset();
+	}
+
+	@Override
+	public void callableSetUp() {
+		IlpTimeOutModelGenerator.persistModel(MODEL_PATH);
+		con = new TimeOutConnector(MODEL_PATH);
+	}
+
+	@Test
+	public void test10to10() {
+		for (int i = 1; i <= 10; i++) {
+			IlpTimeOutModelGenerator.generateTrg("t" + i, 1);
+			IlpTimeOutModelGenerator.generateSrc("s" + i, 1);
+		}
+
+		callableSetUp();
+
+		// There must not be an exception and status must be TIME_OUT
+		final ILPSolverOutput ret = con.run(OUTPUT_PATH);
+		IlpTimeOutModelGenerator.loadModel(OUTPUT_PATH);
+		assertEquals(ILPSolverStatus.TIME_OUT, ret.status());
+
+		// TODO: Check if solution was found
+		// There must be no embedding at all -> no solution found -> no solution applied
+		checkNoMapping();
+	}
+
+	@Test
+	public void test100to100() {
+		for (int i = 1; i <= 100; i++) {
+			IlpTimeOutModelGenerator.generateTrg("t" + i, 1);
+			IlpTimeOutModelGenerator.generateSrc("s" + i, 1);
+		}
+
+		callableSetUp();
+
+		// There must not be an exception and status must be TIME_OUT
+		final ILPSolverOutput ret = con.run(OUTPUT_PATH);
+		IlpTimeOutModelGenerator.loadModel(OUTPUT_PATH);
+		assertEquals(ILPSolverStatus.TIME_OUT, ret.status());
+
+		// TODO: Check if solution was found
+		// There must be no embedding at all -> no solution found -> no solution applied
+		checkNoMapping();
+	}
+
+	@Disabled
+	@Test
+	public void test200to200() {
+		for (int i = 1; i <= 200; i++) {
+			IlpTimeOutModelGenerator.generateTrg("t" + i, 1);
+			IlpTimeOutModelGenerator.generateSrc("s" + i, 1);
+		}
+
+		callableSetUp();
+
+		// There must not be an exception and status must be TIME_OUT
+		final ILPSolverOutput ret = con.run(OUTPUT_PATH);
+		IlpTimeOutModelGenerator.loadModel(OUTPUT_PATH);
+		assertEquals(ILPSolverStatus.TIME_OUT, ret.status());
+
+		// TODO: Check if solution was found
+		// There must be no embedding at all -> no solution found -> no solution applied
+		checkNoMapping();
+	}
+
+	private void checkNoMapping() {
+		IlpTimeOutModelGenerator.getElements().forEach(e -> {
+			if (e instanceof Source s) {
+				assertNull(s.getHost());
+			} else if (e instanceof Target t) {
+				assertTrue(t.getSrcs().isEmpty());
+				assertEquals(t.getVal(), t.getFree());
+			}
+		});
+	}
+
+}

--- a/test.suite.gips/src/test/suite/gips/ilp/timeout/IlpTimeOutModelGenerator.java
+++ b/test.suite.gips/src/test/suite/gips/ilp/timeout/IlpTimeOutModelGenerator.java
@@ -1,0 +1,79 @@
+package test.suite.gips.ilp.timeout;
+
+import java.io.IOException;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+import org.emoflon.smartemf.persistence.SmartEMFResourceFactoryImpl;
+import org.emoflon.smartemf.runtime.collections.LinkedSmartESet;
+
+import timeoutmodel.Element;
+import timeoutmodel.Root;
+import timeoutmodel.Source;
+import timeoutmodel.Target;
+import timeoutmodel.TimeoutmodelFactory;
+
+public class IlpTimeOutModelGenerator {
+
+	private static Root root = TimeoutmodelFactory.eINSTANCE.createRoot();
+
+	public static Root getRoot() {
+		return root;
+	}
+
+	public static LinkedSmartESet<Element> getElements() {
+		return root.getElements();
+	}
+
+	public static void reset() {
+		root = TimeoutmodelFactory.eINSTANCE.createRoot();
+	}
+
+	public static void generateSrc(final String id, final int val) {
+		final Source src = TimeoutmodelFactory.eINSTANCE.createSource();
+		src.setId(id);
+		src.setVal(val);
+		getElements().add(src);
+	}
+
+	public static void generateTrg(final String id, final int val) {
+		final Target trg = TimeoutmodelFactory.eINSTANCE.createTarget();
+		trg.setId(id);
+		trg.setVal(val);
+		trg.setFree(val);
+		getElements().add(trg);
+	}
+
+	public static Root loadModel(final String path) {
+		// Workaround: Always use absolute path
+		final URI absPath = URI.createFileURI(System.getProperty("user.dir") + "/" + path);
+
+		final ResourceSet rs = new ResourceSetImpl();
+		rs.getResourceFactoryRegistry().getExtensionToFactoryMap().put("xmi", new SmartEMFResourceFactoryImpl(null));
+		// ^null is okay if all paths are absolute
+		final Resource res = rs.getResource(absPath, true);
+		root = (Root) res.getContents().get(0);
+		return root;
+	}
+
+	public static void persistModel(final String path) {
+		// Workaround: Always use absolute path
+		final URI absPath = URI.createFileURI(System.getProperty("user.dir") + "/" + path);
+
+		// Create new model for saving
+		final ResourceSet rs = new ResourceSetImpl();
+		rs.getResourceFactoryRegistry().getExtensionToFactoryMap().put("xmi", new SmartEMFResourceFactoryImpl(null));
+		// ^null is okay if all paths are absolute
+		final Resource r = rs.createResource(absPath);
+		// Fetch model contents from eMoflon
+		r.getContents().add(root);
+		try {
+			r.save(null);
+		} catch (final IOException e) {
+			e.printStackTrace();
+		}
+	}
+
+}


### PR DESCRIPTION
Blocked by https://github.com/Echtzeitsysteme/gips/pull/62.

Maybe I have to think about another clever test case that reliably triggers the solver status `TIME_OUT` but without a found solution.