### PR TITLE
Removes duplex host edges in all GIPSL specifications

### DIFF
--- a/gipsl.all.build.and/src/gipsl/all/build/and/Model.gipsl
+++ b/gipsl.all.build.and/src/gipsl/all/build/and/Model.gipsl
@@ -24,9 +24,7 @@ rule mapVnode {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode

--- a/gipsl.all.build.complex/src/gipsl/all/build/complex/Model.gipsl
+++ b/gipsl.all.build.complex/src/gipsl/all/build/complex/Model.gipsl
@@ -29,9 +29,7 @@ rule mapVnode {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode

--- a/gipsl.all.build.count/src/gipsl/all/build/count/Model.gipsl
+++ b/gipsl.all.build.count/src/gipsl/all/build/count/Model.gipsl
@@ -38,10 +38,8 @@ rule mapVnode {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
-	
+	snode: SubstrateResourceNode
+		
 	vnode: VirtualResourceNode {
 		++ -host -> snode
 	}

--- a/gipsl.all.build.filter/src/gipsl/all/build/filter/Model.gipsl
+++ b/gipsl.all.build.filter/src/gipsl/all/build/filter/Model.gipsl
@@ -38,9 +38,7 @@ rule mapVnode {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode

--- a/gipsl.all.build.implication/src/gipsl/all/build/implication/Model.gipsl
+++ b/gipsl.all.build.implication/src/gipsl/all/build/implication/Model.gipsl
@@ -24,9 +24,7 @@ rule mapVnode {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode

--- a/gipsl.all.build.implicationstatic/src/gipsl/all/build/implicationstatic/Model.gipsl
+++ b/gipsl.all.build.implicationstatic/src/gipsl/all/build/implicationstatic/Model.gipsl
@@ -24,9 +24,7 @@ rule mapVnode {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode

--- a/gipsl.all.build.model/model/Model.ecore
+++ b/gipsl.all.build.model/model/Model.ecore
@@ -23,11 +23,12 @@
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Node" abstract="true" eSuperTypes="#//Element"/>
   <eClassifiers xsi:type="ecore:EClass" name="VirtualNode" abstract="true" eSuperTypes="#//Node">
-    <eStructuralFeatures xsi:type="ecore:EReference" name="host" lowerBound="1" eType="#//SubstrateNode"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="host" lowerBound="1" eType="#//SubstrateNode"
+        eOpposite="#//SubstrateNode/guests"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="SubstrateNode" abstract="true" eSuperTypes="#//Node">
     <eStructuralFeatures xsi:type="ecore:EReference" name="guests" upperBound="-1"
-        eType="#//VirtualNode"/>
+        eType="#//VirtualNode" eOpposite="#//VirtualNode/host"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="VirtualResourceNode" eSuperTypes="#//VirtualNode">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="resourceDemand" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt"/>

--- a/gipsl.all.build.not/src/gipsl/all/build/not/Model.gipsl
+++ b/gipsl.all.build.not/src/gipsl/all/build/not/Model.gipsl
@@ -25,9 +25,7 @@ rule mapVnode {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode

--- a/gipsl.all.build.objective.max/src/gipsl/all/build/objective/max/Model.gipsl
+++ b/gipsl.all.build.objective.max/src/gipsl/all/build/objective/max/Model.gipsl
@@ -24,9 +24,7 @@ rule mapVnode {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode

--- a/gipsl.all.build.objective.min/src/gipsl/all/build/objective/min/Model.gipsl
+++ b/gipsl.all.build.objective.min/src/gipsl/all/build/objective/min/Model.gipsl
@@ -24,9 +24,7 @@ rule mapVnode {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode

--- a/gipsl.all.build.objective.scaling/src/gipsl/all/build/objective/scaling/Model.gipsl
+++ b/gipsl.all.build.objective.scaling/src/gipsl/all/build/objective/scaling/Model.gipsl
@@ -23,9 +23,7 @@ rule mapVnodeOne {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode
@@ -48,9 +46,7 @@ rule mapVnodeTwo {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode
@@ -73,9 +69,7 @@ rule mapVnodeTen {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode
@@ -98,9 +92,7 @@ rule mapVnodeTwenty {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode
@@ -123,9 +115,7 @@ rule mapVnodeTwentyOne {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode
@@ -147,9 +137,7 @@ rule mapVnodeTwentyTwo {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode
@@ -172,9 +160,7 @@ rule mapVnodeThirtyThree {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode
@@ -197,9 +183,7 @@ rule mapVnodeFourty {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode

--- a/gipsl.all.build.objective/src/gipsl/all/build/objective/Model.gipsl
+++ b/gipsl.all.build.objective/src/gipsl/all/build/objective/Model.gipsl
@@ -38,9 +38,7 @@ rule mapVnode {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode

--- a/gipsl.all.build.objectivemapping/src/gipsl/all/build/objectivemapping/Model.gipsl
+++ b/gipsl.all.build.objectivemapping/src/gipsl/all/build/objectivemapping/Model.gipsl
@@ -23,9 +23,7 @@ rule mapVnode {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode
@@ -46,9 +44,7 @@ rule mapVnodeTen {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode

--- a/gipsl.all.build.or.a/src/gipsl/all/build/or/a/Model.gipsl
+++ b/gipsl.all.build.or.a/src/gipsl/all/build/or/a/Model.gipsl
@@ -24,9 +24,7 @@ rule mapVnode {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode

--- a/gipsl.all.build.or.b/src/gipsl/all/build/or/b/Model.gipsl
+++ b/gipsl.all.build.or.b/src/gipsl/all/build/or/b/Model.gipsl
@@ -24,9 +24,7 @@ rule mapVnode {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode

--- a/gipsl.all.build.or.extendedorconstant/src/gipsl/all/build/or/extendedorconstant/Model.gipsl
+++ b/gipsl.all.build.or.extendedorconstant/src/gipsl/all/build/or/extendedorconstant/Model.gipsl
@@ -24,9 +24,7 @@ rule mapVnode {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode

--- a/gipsl.all.build.or.extendedortrue/src/gipsl/all/build/or/extendedortrue/Model.gipsl
+++ b/gipsl.all.build.or.extendedortrue/src/gipsl/all/build/or/extendedortrue/Model.gipsl
@@ -24,9 +24,7 @@ rule mapVnode {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode

--- a/gipsl.all.build.resourceinit.infthenopt/src/gipsl/all/build/resourceinit/infthenopt/Model.gipsl
+++ b/gipsl.all.build.resourceinit.infthenopt/src/gipsl/all/build/resourceinit/infthenopt/Model.gipsl
@@ -23,9 +23,7 @@ rule mapVnode {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode

--- a/gipsl.all.build.resourceinit.infthenoptobjective/src/gipsl/all/build/resourceinit/infthenoptobjective/Model.gipsl
+++ b/gipsl.all.build.resourceinit.infthenoptobjective/src/gipsl/all/build/resourceinit/infthenoptobjective/Model.gipsl
@@ -23,9 +23,7 @@ rule mapVnode {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode

--- a/gipsl.all.build.resourcesetinit/src/gipsl/all/build/resourcesetinit/Model.gipsl
+++ b/gipsl.all.build.resourcesetinit/src/gipsl/all/build/resourcesetinit/Model.gipsl
@@ -23,9 +23,7 @@ rule mapVnode {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode

--- a/gipsl.all.build.resourcesinit.optthenvallog/src/gipsl/all/build/resourcesinit/optthenvallog/Model.gipsl
+++ b/gipsl.all.build.resourcesinit.optthenvallog/src/gipsl/all/build/resourcesinit/optthenvallog/Model.gipsl
@@ -23,9 +23,7 @@ rule mapVnode {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode

--- a/gipsl.all.build.simple/src/gipsl/all/build/simple/Model.gipsl
+++ b/gipsl.all.build.simple/src/gipsl/all/build/simple/Model.gipsl
@@ -38,9 +38,7 @@ rule mapVnode {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode

--- a/gipsl.all.build.sumesum/src/gipsl/all/build/sumesum/Model.gipsl
+++ b/gipsl.all.build.sumesum/src/gipsl/all/build/sumesum/Model.gipsl
@@ -25,9 +25,7 @@ rule mapVnode {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode

--- a/gipsl.all.build.sumvalue/src/gipsl/all/build/sumvalue/Model.gipsl
+++ b/gipsl.all.build.sumvalue/src/gipsl/all/build/sumvalue/Model.gipsl
@@ -38,9 +38,7 @@ rule mapVnode {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode

--- a/gipsl.all.build.sumvalueinf/src/gipsl/all/build/sumvalueinf/Model.gipsl
+++ b/gipsl.all.build.sumvalueinf/src/gipsl/all/build/sumvalueinf/Model.gipsl
@@ -38,9 +38,7 @@ rule mapVnode {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode

--- a/gipsl.all.build.vardoubleimpl/src/gipsl/all/build/vardoubleimpl/Model.gipsl
+++ b/gipsl.all.build.vardoubleimpl/src/gipsl/all/build/vardoubleimpl/Model.gipsl
@@ -24,9 +24,7 @@ rule mapVnode {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode

--- a/gipsl.all.build.varequivalence/src/gipsl/all/build/varequivalence/Model.gipsl
+++ b/gipsl.all.build.varequivalence/src/gipsl/all/build/varequivalence/Model.gipsl
@@ -24,9 +24,7 @@ rule mapVnode {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode

--- a/gipsl.all.build.varlimit/src/gipsl/all/build/varlimit/Model.gipsl
+++ b/gipsl.all.build.varlimit/src/gipsl/all/build/varlimit/Model.gipsl
@@ -38,9 +38,7 @@ rule mapVnode {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode

--- a/gipsl.all.build.varmappingsum.sumfreevarmapping/src/gipsl/all/build/varmappingsum/sumfreevarmapping/Model.gipsl
+++ b/gipsl.all.build.varmappingsum.sumfreevarmapping/src/gipsl/all/build/varmappingsum/sumfreevarmapping/Model.gipsl
@@ -24,9 +24,7 @@ rule mapVnode {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode

--- a/gipsl.all.build.varmappingsum.sumfreevarmult/src/gipsl/all/build/varmappingsum/sumfreevarmult/Model.gipsl
+++ b/gipsl.all.build.varmappingsum.sumfreevarmult/src/gipsl/all/build/varmappingsum/sumfreevarmult/Model.gipsl
@@ -24,9 +24,7 @@ rule mapVnode {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode

--- a/gipsl.all.build.varmappingsum.sumfreevarmultb/src/gipsl/all/build/varmappingsum/sumfreevarmultb/Model.gipsl
+++ b/gipsl.all.build.varmappingsum.sumfreevarmultb/src/gipsl/all/build/varmappingsum/sumfreevarmultb/Model.gipsl
@@ -24,10 +24,8 @@ rule mapVnode {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
-	
+	snode: SubstrateResourceNode
+
 	vnode: VirtualResourceNode {
 		++ -host -> snode
 	}

--- a/gipsl.all.build.varnamebug/src/gipsl/all/build/varnamebug/Model.gipsl
+++ b/gipsl.all.build.varnamebug/src/gipsl/all/build/varnamebug/Model.gipsl
@@ -23,9 +23,7 @@ rule mapVnode {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode

--- a/gipsl.all.build.vars/src/gipsl/all/build/vars/Model.gipsl
+++ b/gipsl.all.build.vars/src/gipsl/all/build/vars/Model.gipsl
@@ -25,9 +25,7 @@ rule mapVnode {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode

--- a/gipsl.all.build.varsmappingsum/src/gipsl/all/build/varsmappingsum/Model.gipsl
+++ b/gipsl.all.build.varsmappingsum/src/gipsl/all/build/varsmappingsum/Model.gipsl
@@ -25,9 +25,7 @@ rule mapVnode {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode

--- a/gipsl.all.build.varsobjective/src/gipsl/all/build/varsobjective/Model.gipsl
+++ b/gipsl.all.build.varsobjective/src/gipsl/all/build/varsobjective/Model.gipsl
@@ -25,9 +25,7 @@ rule mapVnode {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode

--- a/gipsl.all.build.varsparameter/src/gipsl/all/build/varsparameter/Model.gipsl
+++ b/gipsl.all.build.varsparameter/src/gipsl/all/build/varsparameter/Model.gipsl
@@ -26,7 +26,6 @@ rule mapVnode(par : EInt) {
 	}
 	
 	snode: SubstrateResourceNode {
-		++ -guests -> vnode
 		.resourceAmountAvailable := param::par
 	}
 	

--- a/gipsl.all.build.varssum/src/gipsl/all/build/varssum/Model.gipsl
+++ b/gipsl.all.build.varssum/src/gipsl/all/build/varssum/Model.gipsl
@@ -25,9 +25,7 @@ rule mapVnode {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode

--- a/gipsl.imports.supera/src/gipsl/imports/supera/Model.gipsl
+++ b/gipsl.imports.supera/src/gipsl/imports/supera/Model.gipsl
@@ -16,9 +16,7 @@ rule mapGuestA {
 		-elements -> g
 	}
 	
-	h: Host {
-		++ -guests -> g
-	}
+	h: Host
 	
 	g: Guest {
 		++ -host -> h

--- a/gipsl.scribble/src/gipsl/scribble/Model.gipsl
+++ b/gipsl.scribble/src/gipsl/scribble/Model.gipsl
@@ -26,9 +26,7 @@ rule mapVnode {
 		-virtualNodes -> vnode
 	}
 	
-	snode: SubstrateResourceNode {
-		++ -guests -> vnode
-	}
+	snode: SubstrateResourceNode
 	
 	vnode: VirtualResourceNode {
 		++ -host -> snode


### PR DESCRIPTION
- gipsl.all.build.model: EOpposite for host + guests and removes duplex edges in GIPSL specifications
- Removes duplex host edges in all other GIPSL projects