### PR TITLE
- added lower bounds constraint for the free integer variable

### DIFF
--- a/gipsl.all.build.vardoubleimpl/src/gipsl/all/build/vardoubleimpl/Model.gipsl
+++ b/gipsl.all.build.vardoubleimpl/src/gipsl/all/build/vardoubleimpl/Model.gipsl
@@ -59,6 +59,11 @@ constraint -> mapping::n2n {
 	[self.value() >= 1 => self.variables().v >= 1]
 }
 
+// Limit the value of the integer variable to positive values only.
+constraint -> mapping::n2n {
+	self.variables().v >= 0
+}
+
 objective n2nObj -> mapping::n2n {
 	1
 }

--- a/gipsl.all.build.varequivalence/src/gipsl/all/build/varequivalence/Model.gipsl
+++ b/gipsl.all.build.varequivalence/src/gipsl/all/build/varequivalence/Model.gipsl
@@ -58,6 +58,11 @@ constraint -> mapping::n2n {
 	self.value() >= 1 <=> self.variables().v >= 1
 }
 
+// Limit the value of the integer variable to positive values only.
+constraint -> mapping::n2n {
+	self.variables().v >= 0
+}
+
 objective n2nObj -> mapping::n2n {
 	1
 }


### PR DESCRIPTION
- Explanation: The equivalence constraint forces the free variabe fv >= 1 iff the mapping variable mv >= 1. But if mv is not 1, then fv is allowed to have literally any value other than values > 0. In the Test it is checked, if fv == 0, when mv == 0. This will only work if fv is a binary variable, otherwise it might or might not work depending on the random choice of the used solver, since fv can still have valid values in [-9999, 0] and not violate the initial constraint. To fix that i have added a simple lower bound to the specifaction, that forces fv >= 0. In this case fv will behave just like a binary variable and be 0 in case mv == 0.