### PR TITLE
Fixes the GT termination test

### DIFF
--- a/test.suite.gips/META-INF/MANIFEST.MF
+++ b/test.suite.gips/META-INF/MANIFEST.MF
@@ -21,7 +21,8 @@ Require-Bundle: junit-jupiter-api;bundle-version="5.9.0",
  gips.nullmodel;bundle-version="0.0.1",
  gips.scheduling.taskmodel;bundle-version="0.0.1",
  gips.enummodel;bundle-version="0.0.1",
- genericgraphmetamodel;bundle-version="0.0.1"
+ genericgraphmetamodel;bundle-version="0.0.1",
+ org.emoflon.ibex.common
 Import-Package: gips.enumequals.connector,
  gips.generic.scheduling.codegenintreducebug.connector,
  gips.generic.scheduling.connector,
@@ -86,6 +87,8 @@ Import-Package: gips.enumequals.connector,
  gipsl.string.compare.filter.connector,
  gipsl.string.compare.nonmappingcontext.connector,
  gipsprojectpackagenamebug.connector,
+ hipe.engine,
+ org.emoflon.ibex.gt.hipe.runtime,
  org.junit.jupiter.api,
  shortestpath.connector,
  test.suite.gips.utils

--- a/test.suite.gips/src/test/suite/gips/gttermination/GipsGtTerminationTest.java
+++ b/test.suite.gips/src/test/suite/gips/gttermination/GipsGtTerminationTest.java
@@ -3,6 +3,7 @@ package test.suite.gips.gttermination;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Field;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.concurrent.TimeUnit;
@@ -10,11 +11,14 @@ import java.util.concurrent.TimeUnit;
 import org.emoflon.gips.core.ilp.ILPSolverOutput;
 import org.emoflon.gips.core.ilp.ILPSolverStatus;
 import org.emoflon.ibex.common.operational.IMatch;
+import org.emoflon.ibex.gt.engine.GraphTransformationInterpreter;
+import org.emoflon.ibex.gt.hipe.runtime.HiPEGTEngine;
+import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import gips.gttermination.connector.GtTerminationConnector;
-import model.Root;
+import hipe.engine.HiPEContentAdapter;
 import test.suite.gipsl.all.build.AGipslAllBuildTest;
 
 public class GipsGtTerminationTest extends AGipslAllBuildTest {
@@ -33,7 +37,7 @@ public class GipsGtTerminationTest extends AGipslAllBuildTest {
 
 	// Actual tests
 
-	@Timeout(value = 1, unit = TimeUnit.SECONDS)
+	@Timeout(value = 2, unit = TimeUnit.SECONDS)
 	@Test
 	public void testGtTermination() {
 		gen.genSubstrateNode("s1", 2);
@@ -46,28 +50,51 @@ public class GipsGtTerminationTest extends AGipslAllBuildTest {
 
 		// Get the interpreter and check number of matches before the termination
 		// (must be 2)
-		final var interpreter = ((GtTerminationConnector) con).getEmoflonApi().getInterpreter();
+		final GraphTransformationInterpreter interpreter = ((GtTerminationConnector) con).getEmoflonApi()
+				.getInterpreter();
 		final Iterator<Collection<IMatch>> it = interpreter.getMatches().values().iterator();
 		assertTrue(it.hasNext());
 		final var matches = it.next();
 		assertEquals(2, matches.size());
 
 		// Terminate the GIPS API; this should also terminate the GT interpreter
-		((GtTerminationConnector) con).terminate();
+		con.terminate();
 
-		// Remove model elements such that all matches are invalid
-		var res = ((GtTerminationConnector) con).getEmoflonApi().getModel().getResources().get(0);
-		final Root root = (Root) res.getContents().get(0);
-		root.getContainers().clear();
+		// Check if actual GT interpreter (in this case HiPE) was terminated
+		//
+		// Unfortunately, there is no method/field we can access to check if HiPE was
+		// terminated
+		boolean wasHipeTerminated = false;
+		try {
+			// Get the eMoflon::IBeX API object from the GIPS test project connector
+			final var emoflonApi = ((GtTerminationConnector) con).getEmoflonApi();
 
-		// Update matches
-		interpreter.updateMatches();
+			// The IBeX API has a field called "contextPatternInterpreter" which contains
+			// the HiPEGTEngine object. It is not publicly available, but we want this
+			// object -> use reflection to get it's value.
+			final Field contextPatternInterpreterField = GraphTransformationInterpreter.class
+					.getDeclaredField("contextPatternInterpreter");
+			contextPatternInterpreterField.setAccessible(true);
+			final HiPEGTEngine hipeEngine = (HiPEGTEngine) contextPatternInterpreterField
+					.get(emoflonApi.getInterpreter());
 
-		// Now, **two** matches must still be present
-		final Iterator<Collection<IMatch>> it2 = interpreter.getMatches().values().iterator();
-		assertTrue(it2.hasNext());
-		final var matches2 = it2.next();
-		assertEquals(2, matches2.size(), "GT engine termination failed.");
+			// The HiPE engine object has a field called "adapter" -> reflection again
+			final Field adapterField = HiPEGTEngine.class.getDeclaredField("adapter");
+			adapterField.setAccessible(true);
+			final HiPEContentAdapter contentAdapter = (HiPEContentAdapter) adapterField.get(hipeEngine);
+
+			// The HiPEContentAdapter object contains a field "terminated" -> reflection
+			final Field hipeTerminatedField = HiPEContentAdapter.class.getDeclaredField("terminated");
+			hipeTerminatedField.setAccessible(true);
+			wasHipeTerminated = hipeTerminatedField.getBoolean(contentAdapter);
+		} catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
+			// If any of the exceptions above occurred during the test, the test must fail.
+			Assert.fail(e.getMessage());
+		}
+
+		// HiPE must be properly terminated, i.e., the field must have been set to
+		// `true`.
+		assertTrue(wasHipeTerminated);
 	}
 
 	@Override


### PR DESCRIPTION
The new test implementation uses reflection to check if HiPE got the "terminate" call via the eMoflon::IBeX API.

Closes #64.