### PR TITLE
Adds a dummy pattern as context for a mapping to reproduce a bug regarding free boolean variables

### DIFF
--- a/gipsl.all.build.varsbooleanbug/src/gipsl/all/build/varsbooleanbug/Model.gipsl
+++ b/gipsl.all.build.varsbooleanbug/src/gipsl/all/build/varsbooleanbug/Model.gipsl
@@ -31,6 +31,10 @@ rule mapVnode {
 	}
 }
 
+pattern dummyPattern {
+	root : Root
+}
+
 rule setDummyAttrRoot(p: EBoolean) {
 	root: Root {
 		.dummyAttribute := true
@@ -48,6 +52,10 @@ mapping n2n to mapVnode {
 
 mapping dummyM to setDummyAttrRoot {
 	var x : EBoolean bind p
+};
+
+mapping dummyPatternM to dummyPattern {
+	var b : EBoolean
 };
 
 constraint with VirtualResourceNode {


### PR DESCRIPTION
Related to https://github.com/Echtzeitsysteme/gips-tests/pull/57/files#diff-4fd91c1f682bbdca9ece35fe3d7416c69448ea66afaf5061b342b03b0fb6e265.